### PR TITLE
Add a context manager for relative bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ ellipses = Arrange(
     gap=500,
 )
 
-arrow = Arrow(
-    ellipses.child_bounds(left_ellipse).corners[Corner.MIDDLE_RIGHT],
-    ellipses.child_bounds(right_ellipse).corners[Corner.MIDDLE_LEFT],
-    line_path_style=PathStyle(
-        color=Colors.BLACK,
-        thickness=3,
-    ),
-)
+with ellipses:
+    arrow = Arrow(
+        left_ellipse.bounds.corners[Corner.MIDDLE_RIGHT],
+        right_ellipse.bounds.corners[Corner.MIDDLE_LEFT],
+        line_path_style=PathStyle(
+            color=Colors.BLACK,
+            thickness=3,
+        ),
+    )
 arrow_label = MathTex("f(x) = x^2", scale=4)
 arrow = LabelArrow(
     arrow,

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -44,14 +44,15 @@ if __name__ == "__main__":
         gap=500,
     )
 
-    arrow = Arrow(
-        ellipses.child_bounds(left_ellipse).corners[Corner.MIDDLE_RIGHT],
-        ellipses.child_bounds(right_ellipse).corners[Corner.MIDDLE_LEFT],
-        line_path_style=PathStyle(
-            color=Colors.BLACK,
-            thickness=3,
-        ),
-    )
+    with ellipses:
+        arrow = Arrow(
+            left_ellipse.bounds.corners[Corner.MIDDLE_RIGHT],
+            right_ellipse.bounds.corners[Corner.MIDDLE_LEFT],
+            line_path_style=PathStyle(
+                color=Colors.BLACK,
+                thickness=3,
+            ),
+        )
     arrow_label = MathTex("f(x) = x^2", scale=4)
     arrow = LabelArrow(
         arrow,

--- a/examples/neural_network.py
+++ b/examples/neural_network.py
@@ -78,18 +78,19 @@ class NeuralNetwork(Compose):
 
         # Draw the lines.
         self._lines = []
-        for layer_a, layer_b in zip(self.layer_nodes[:-1], self.layer_nodes[1:]):
-            for circle_a in layer_a:
-                for circle_b in layer_b:
-                    start = nodes_arranged.child_bounds(circle_a).corners[
-                        Corner.MIDDLE_RIGHT
-                    ]
-                    end = nodes_arranged.child_bounds(circle_b).corners[
-                        Corner.MIDDLE_LEFT
-                    ]
+        with nodes_arranged:
+            for layer_a, layer_b in zip(self.layer_nodes[:-1], self.layer_nodes[1:]):
+                for circle_a in layer_a:
+                    for circle_b in layer_b:
+                        start = circle_a.bounds.corners[
+                            Corner.MIDDLE_RIGHT
+                        ]
+                        end = circle_b.bounds.corners[
+                            Corner.MIDDLE_LEFT
+                        ]
 
-                    line = Line(start, end, self._line_path_style)
-                    self._lines.append(line)
+                        line = Line(start, end, self._line_path_style)
+                        self._lines.append(line)
 
         # All the children in this composition.
         # Nodes are drawn on top of lines.

--- a/iceberg/primitives/filters.py
+++ b/iceberg/primitives/filters.py
@@ -12,7 +12,7 @@ class Filter(Drawable):
         self._child = child
         picture_recorder = skia.PictureRecorder()
         fake_canvas = picture_recorder.beginRecording(
-            child.bounds.width, child.bounds.height
+            child.native_bounds.width, child.native_bounds.height
         )
         child.draw(fake_canvas)
         self._skia_picture = picture_recorder.finishRecordingAsPicture()
@@ -22,8 +22,8 @@ class Filter(Drawable):
         return [self._child]
 
     @property
-    def bounds(self) -> Bounds:
-        return self._child.bounds
+    def native_bounds(self) -> Bounds:
+        return self._child.native_bounds
 
     def draw(self, canvas: skia.Canvas) -> None:
         canvas.drawPicture(self._skia_picture, paint=self._paint)

--- a/iceberg/primitives/image.py
+++ b/iceberg/primitives/image.py
@@ -39,7 +39,7 @@ class Image(Drawable):
         )
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._bounds
 
     def draw(self, canvas: skia.Canvas) -> None:

--- a/iceberg/primitives/layout.py
+++ b/iceberg/primitives/layout.py
@@ -47,7 +47,7 @@ class Blank(Drawable):
         )
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._bounds
 
     def draw(self, canvas: skia.Canvas) -> None:
@@ -84,7 +84,7 @@ class Transform(Drawable):
         self._scale = scale
         self._anchor = anchor
 
-        self._child_bounds = self._child.bounds
+        self._child_bounds = self._child.native_bounds
 
         # Compute the bounds of the transformed child.
         left, top = self._child_bounds.left, self._child_bounds.top
@@ -140,7 +140,7 @@ class Transform(Drawable):
         return self._child
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._transformed_bounds
 
     def draw(self, canvas: skia.Canvas):
@@ -185,7 +185,7 @@ class Padding(Transform):
             )
 
         self._padding = padding
-        self._child_bounds = self._child.bounds
+        self._child_bounds = self._child.native_bounds
 
         pl, pt, pr, pb = self._padding
 
@@ -202,7 +202,7 @@ class Padding(Transform):
         )
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._padded_bounds
 
 
@@ -221,10 +221,10 @@ class Compose(Drawable):
 
         if len(self._children):
             # Compute the bounds of the composed children.
-            left = min([child.bounds.left for child in self._children])
-            top = min([child.bounds.top for child in self._children])
-            right = max([child.bounds.right for child in self._children])
-            bottom = max([child.bounds.bottom for child in self._children])
+            left = min([child.native_bounds.left for child in self._children])
+            top = min([child.native_bounds.top for child in self._children])
+            right = max([child.native_bounds.right for child in self._children])
+            bottom = max([child.native_bounds.bottom for child in self._children])
 
             self._composed_bounds = Bounds(
                 left=left,
@@ -238,7 +238,7 @@ class Compose(Drawable):
         return self._children
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._composed_bounds
 
     def draw(self, canvas: skia.Canvas):
@@ -271,8 +271,8 @@ class Anchor(Compose):
         return self._children[self._anchor_index]
 
     @property
-    def bounds(self) -> Bounds:
-        return self.anchor.bounds
+    def native_bounds(self) -> Bounds:
+        return self.anchor.native_bounds
 
 
 class Align(Compose):
@@ -308,8 +308,8 @@ class Align(Compose):
             direction: The direction to move the child drawable in.
         """
 
-        anchor_corner = anchor.bounds.corners[anchor_corner]
-        child_corner = child.bounds.corners[child_corner]
+        anchor_corner = anchor.native_bounds.corners[anchor_corner]
+        child_corner = child.native_bounds.corners[child_corner]
 
         dx = anchor_corner[0] - child_corner[0]
         dy = anchor_corner[1] - child_corner[1]
@@ -401,9 +401,9 @@ class Grid(Compose):
                 child = child.pad(_conditional_padding(x, y)).move(current_x, current_y)
                 self._padded_children.append(child)
 
-                current_x += child.bounds.width
+                current_x += child.native_bounds.width
 
-            current_y += child.bounds.height
+            current_y += child.native_bounds.height
             current_x = 0
 
         super().__init__(children=tuple(self._padded_children))

--- a/iceberg/primitives/shapes.py
+++ b/iceberg/primitives/shapes.py
@@ -73,7 +73,7 @@ class Rectangle(Drawable):
             ).to_skia()
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._bounds
 
     def draw(self, canvas):
@@ -112,7 +112,7 @@ class Path(Drawable, ABC):
         self._path_style = path_style
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._bounds
 
     def draw(self, canvas):

--- a/iceberg/primitives/svg.py
+++ b/iceberg/primitives/svg.py
@@ -44,7 +44,7 @@ class SVG(Drawable):
         self._skia_picture = picture_recorder.finishRecordingAsPicture()
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._bounds
 
     def draw(self, canvas: skia.Canvas) -> None:

--- a/iceberg/primitives/text.py
+++ b/iceberg/primitives/text.py
@@ -28,7 +28,7 @@ class SimpleText(Drawable):
         )
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return self._bounds
 
     def draw(self, canvas: skia.Canvas) -> None:
@@ -103,7 +103,7 @@ class Text(Drawable):
         )
 
     @property
-    def bounds(self) -> Bounds:
+    def native_bounds(self) -> Bounds:
         return Bounds(
             left=0,
             top=0,


### PR DESCRIPTION
Usage:
```python
with drawable:
    child.bounds # Equivalent to drawable.child_bounds(child)
```