### PR TITLE
Overlay grid

### DIFF
--- a/iceberg/core/drawable.py
+++ b/iceberg/core/drawable.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple, Sequence, Callable
+from typing import Optional, Union, Tuple, Sequence, Callable
 
 from abc import ABC, abstractmethod, abstractproperty
 from iceberg.core import Bounds, Corner
@@ -95,9 +95,23 @@ class Drawable(ABC):
         cx, cy = self.bounds.corners[corner]
         return self.move(-cx, -cy)
 
-    def move(self, x: float, y: float):
-        """Move the drawable by the specified amount."""
+    def move(self, x: float, y: float, corner: Optional[Corner] = None):
+        """Move the drawable by the specified amount.
+
+        Args:
+            x: The amount to move in the x direction.
+            y: The amount to move in the y direction.
+            corner: If specified, then the specified corner will be moved by the
+                specified amount, relative to the current position of the *top-left*
+                corner. In particular, if the top-left corner is currently at (0, 0),
+                then the specified corner will be moved to (x, y).
+        """
         from iceberg.primitives.layout import Transform
+
+        if corner is not None:
+            cx, cy = self.bounds.corners[corner]
+            x -= cx
+            y -= cy
 
         return Transform(
             child=self,

--- a/iceberg/primitives/__init__.py
+++ b/iceberg/primitives/__init__.py
@@ -6,6 +6,7 @@ from .shapes import (
     Path,
     CurvedCubicLine,
     PartialPath,
+    GridOverlay,
 )
 from .layout import (
     Transform,

--- a/iceberg/primitives/shapes.py
+++ b/iceberg/primitives/shapes.py
@@ -1,7 +1,7 @@
 from typing import List, Sequence, Tuple, Union
 import skia
 
-from iceberg import Drawable, Bounds, Color, FontStyle, Corner
+from iceberg import Drawable, Bounds, Color, FontStyle, Corner, Colors
 from iceberg.animation import Animatable
 from iceberg.animation.animatable import AnimatableSequence
 from iceberg.core import Bounds
@@ -272,23 +272,25 @@ class CurvedCubicLine(Path):
 
 
 class GridOverlay(Compose):
+    """Overlays a grid on top of a scene, for debugging and design."""
+
     def __init__(self, scene: Drawable, spacing: float = 20, label_every: int = 5):
-        self._scene = scene
-        self._spacing = spacing
+        x_lower, x_upper = scene.bounds.left, scene.bounds.right
+        y_lower, y_upper = scene.bounds.top, scene.bounds.bottom
 
-        x_lower, x_upper = self._scene.bounds.left, self._scene.bounds.right
-        y_lower, y_upper = self._scene.bounds.top, self._scene.bounds.bottom
-
+        # Round the lower bounds to the previous multiple of the spacing.
         x_lower = math.floor(x_lower / spacing) * spacing
         y_lower = math.floor(y_lower / spacing) * spacing
 
+        # Number of horizontal and vertical lines
         num_verticals = math.floor((x_upper - x_lower) / spacing)
         num_horizontals = math.floor((y_upper - y_lower) / spacing)
 
+        # Line positions
         xs = [x_lower + spacing * i for i in range(num_verticals + 1)]
         ys = [y_lower + spacing * i for i in range(num_horizontals + 1)]
 
-        # Make the lines longer to make it look nicer
+        # Extend the lines a bit to make the grid look nicer
         x_lower -= spacing / 2
         y_lower -= spacing / 2
         x_upper = max(x_upper, xs[-1] + spacing / 2)
@@ -323,7 +325,7 @@ class GridOverlay(Compose):
         font_style = FontStyle(
             family="Arial",
             size=12,
-            color=Color(0, 0, 0, 0.85),
+            color=Colors.BLACK,
         )
 
         for i, x in enumerate(xs):

--- a/iceberg/primitives/shapes.py
+++ b/iceberg/primitives/shapes.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 import skia
 
 from iceberg import Drawable, Bounds, Color, FontStyle, Corner, Colors
@@ -274,7 +274,13 @@ class CurvedCubicLine(Path):
 class GridOverlay(Compose):
     """Overlays a grid on top of a scene, for debugging and design."""
 
-    def __init__(self, scene: Drawable, spacing: float = 20, label_every: int = 5):
+    def __init__(
+        self,
+        scene: Drawable,
+        spacing: float = 20,
+        label_every: int = 5,
+        color: Color = Colors.BLACK,
+    ):
         x_lower, x_upper = scene.bounds.left, scene.bounds.right
         y_lower, y_upper = scene.bounds.top, scene.bounds.bottom
 
@@ -296,9 +302,8 @@ class GridOverlay(Compose):
         x_upper = max(x_upper, xs[-1] + spacing / 2)
         y_upper = max(y_upper, ys[-1] + spacing / 2)
 
-        color = Color(0, 0, 0, 0.3)
-        style = PathStyle(color, 1)
-        important_style = PathStyle(Color(0, 0, 0, 0.85), 1)
+        style = PathStyle(Color(color.r, color.g, color.b, 0.3), 1)
+        important_style = PathStyle(Color(color.r, color.g, color.b, 0.85), 1)
 
         # Index of the zero line, to figure out which lines to bold and label.
         x_offset_index = xs.index(0) % label_every
@@ -325,7 +330,7 @@ class GridOverlay(Compose):
         font_style = FontStyle(
             family="Arial",
             size=12,
-            color=Colors.BLACK,
+            color=color,
         )
 
         for i, x in enumerate(xs):


### PR DESCRIPTION
Usage:
```python
scene = GridOverlay(scene, spacing=20, label_every=5)
```
will produce something like this:
<img width="762" alt="image" src="https://github.com/revalo/iceberg/assets/6618882/ddea629c-8d90-4980-9f3b-7c8a6e034418">

Note this PR also adds a `corner` argument to `Drawable.move`, which is used by the new `GridOverlay` class. But `GridOverlay` can of course be rewritten without that if you don't like it.

Also, current implementation only makes sense on bright backgrounds, since grid lines are black. We could just make the path style an argument, but it would be nice to not have to pass two arguments (for normal and important lines). Maybe just make the color an argument, and then use different opacities like now for the different lines? That also gives us a color for the text.