### PR TITLE
Cubic interpolation for PartialPath

### DIFF
--- a/iceberg/primitives/shapes.py
+++ b/iceberg/primitives/shapes.py
@@ -162,12 +162,17 @@ class Path(Drawable, ABC):
 
 
 class PartialPath(Drawable, Animatable):
+    class Interpolation(Enum):
+        LINEAR = 0
+        CUBIC = 1
+
     def __init__(
         self,
         child_path: Path,
         start: float = 0,
         end: float = 1,
         subdivide_increment: float = 0.01,
+        interpolation: Interpolation = Interpolation.CUBIC,
     ):
         super().__init__()
 
@@ -176,6 +181,8 @@ class PartialPath(Drawable, Animatable):
         self._child_path = child_path
         self._start = start
         self._end = end
+        self._subdivide_increment = subdivide_increment
+        self._interpolation = interpolation
 
         self._path_measure = skia.PathMeasure(self._child_path.skia_path, False)
         self._total_length = self._path_measure.getLength()
@@ -208,8 +215,38 @@ class PartialPath(Drawable, Animatable):
         self._partial_path = skia.Path()
         self._partial_path.moveTo(*self._points[0])
 
-        for point in self._points[1:]:
-            self._partial_path.lineTo(*point)
+        if interpolation == self.Interpolation.LINEAR:
+            for point in self._points[1:]:
+                self._partial_path.lineTo(*point)
+        elif interpolation == self.Interpolation.CUBIC:
+            segment_length = self._total_length * subdivide_increment
+
+            for point, tangent, next_point, next_tangent in zip(
+                self._points[:-1],
+                self._tangents[:-1],
+                self._points[1:],
+                self._tangents[1:],
+            ):
+                # The tangents are unit vectors, but we would like actual time
+                # derivatives for the conversion below. That's an underspecified
+                # problem (the original path may not even have a notion of time.
+                # But by scaling with the segment length we at least get
+                # a reasonable choice (in particular, this makes the shape of the
+                # interpolation invariant to scaling the entire path).
+                tangent = (tangent[0] * segment_length, tangent[1] * segment_length)
+                next_tangent = (
+                    next_tangent[0] * segment_length,
+                    next_tangent[1] * segment_length,
+                )
+                # Compute control points (i.e. convert from Hermite to Bezier curve):
+                p1 = (point[0] + tangent[0] / 3, point[1] + tangent[1] / 3)
+                p2 = (
+                    next_point[0] - next_tangent[0] / 3,
+                    next_point[1] - next_tangent[1] / 3,
+                )
+                self._partial_path.cubicTo(*p1, *p2, *next_point)
+        else:
+            raise ValueError(f"Unknown interpolation {interpolation}.")
 
     def draw(self, canvas: skia.Canvas):
         canvas.drawPath(self._partial_path, self._child_path._path_style.skia_paint)
@@ -236,7 +273,9 @@ class PartialPath(Drawable, Animatable):
 
     def copy_with_animatables(self, animatables: AnimatableSequence):
         start, end = animatables
-        return PartialPath(self._child_path, start, end)
+        return PartialPath(
+            self._child_path, start, end, self._subdivide_increment, self._interpolation
+        )
 
 
 @dataclass


### PR DESCRIPTION
Modifies PartialPath to use Hermite splines instead of linear ones by default, which leads to smoother looking curves at lower increment resolution. We don't actually have tangents in the time derivative sense, only unit tangents, so we need to pick some way to scale them. I just scaled them by the length of the current segment, which I think is the only choice that makes the shape of the interpolation scale-invariant. (And it looks reasonable in some testing)

Also fixes what I think was a small bug (`subdivide_increment` wasn't restored in `PartialPath.copy_with_animatables()`).

I don't really like the new interpolation enum because it will also be an argument to curved arrows, so it's a bit weird to have it namespaced in `PartialPath`. On the other hand, otherwise it's yet another global enum that needs to be imported, and it isn't actually used in many places. I might just use a string but that clashes with the usual iceberg convention. Finally, we could use a boolean flag---as long as we don't add other interpolations in the future, that's best, unsure whether there's anything else we might want later.

(I don't think we can reuse the enum for curved arrows, since the range of choices will probably diverge)