### PR TITLE
Auto Animatables

### DIFF
--- a/iceberg/animation/__init__.py
+++ b/iceberg/animation/__init__.py
@@ -1,2 +1,3 @@
 from .animatable import Animatable
+from .auto_animatable import auto_animatable
 from .tween import EaseType, tween, tween

--- a/iceberg/animation/auto_animatable.py
+++ b/iceberg/animation/auto_animatable.py
@@ -1,0 +1,134 @@
+import inspect
+import functools
+import numpy as np
+
+from .animatable import Animatable, AnimatableSequence
+
+
+def is_animatable(obj):
+    """Check whether `obj` can be animated."""
+    if isinstance(obj, (Animatable, np.ndarray, float, int)):
+        return True
+    if obj is None:
+        return True
+    if isinstance(obj, (list, tuple)):
+        # In addition to Animatables, we allow lists of floats,
+        # or lists of lists/tuples of floats, since some iceberg classes accept
+        # these instead of numpy arrays.
+        if all(isinstance(item, (float, int)) for item in obj):
+            return True
+        if all(
+            isinstance(item, (tuple, list, np.ndarray))
+            and len(item) == len(obj[0])
+            and all(isinstance(subitem, (float, int)) for subitem in item)
+            for item in obj
+        ):
+            return True
+    return False
+
+
+def as_animatable(obj):
+    """Try to turn `obj` into something to be returned by `Animatable.animatables`."""
+    if isinstance(obj, (Animatable, float, int)) or obj is None:
+        return obj
+    if isinstance(np.ndarray, obj):
+        return obj.reshape(-1)
+    if isinstance(obj, (list, tuple)):
+        return np.array(obj).reshape(-1)
+
+    raise ValueError(f"Object {obj} is not animatable")
+
+
+def auto_animatable(cls):
+    """Class decorator that makes a class Animatable.
+
+    Usage:
+        @auto_animatable
+        class MyClass(Drawable):
+            ...
+
+    This will try to automatically capture all the arguments passed to __init__,
+    detect which of them are animatable, and then add suitable `animatables` and
+    `copy_with_animatables` methods.
+
+    Note that `MyClass` mustn't explicitly inherit from `Animatable`---this would lead
+    to errors as `MyClass` wouldn't have the necessary abstract methods defined.
+    Instead, the decorator will add `Animatable` as a parent class. (Technically,
+    it returns a new class that inherits from `MyClass` and `Animatable`.)
+
+    You can modify the animatables by defining `_transform_export_animatable_dict`
+    and/or `_transform_import_animatable_dict` methods on the class. Both take a dict
+    where keys are names of animatable __init__ kwargs, and values are the __init__
+    arguments. The methods can then return a modified dict.
+
+    This decorator should work for many cases, but in complex scenarios, you will
+    instead need to manually define `animatables` and `copy_with_animatables`.
+    """
+    orig_init = cls.__init__
+    sig = inspect.signature(orig_init)
+
+    @functools.wraps(cls.__init__)
+    def new_init(self, *args, **kwargs):
+        if hasattr(self, "_is_auto_animatable"):
+            # This is the __init__ of a parent class, called from an auto_animatable
+            # child class. No need to do anything here.
+            orig_init(self, *args, **kwargs)
+            return
+
+        # Important to set this before calling orig_init!
+        self._is_auto_animatable = True
+
+        orig_init(self, *args, **kwargs)
+
+        bound = sig.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+
+        self._animatable_keys = []
+        self._shapes = {}
+        self._init_kwargs = {}
+        for key, value in bound.arguments.items():
+            if key == "self":
+                continue
+
+            self._init_kwargs[key] = value
+
+            if is_animatable(value):
+                self._animatable_keys.append(key)
+                if isinstance(value, (np.ndarray, list, tuple)):
+                    value = np.array(value)
+                    self._shapes[key] = value.shape
+
+    cls.__init__ = new_init
+
+    @property
+    def animatables(self) -> AnimatableSequence:
+        if hasattr(self, "_transform_export_animatable_dict"):
+            animatable_dict = self._transform_export_animatable_dict(animatable_dict)
+        animatable_dict = {
+            key: as_animatable(self._init_kwargs[key]) for key in self._animatable_keys
+        }
+        return tuple(animatable_dict.values())
+
+    cls.animatables = animatables
+
+    def copy_with_animatables(self, animatables: AnimatableSequence):
+        animatable_dict = dict(zip(self._animatable_keys, animatables))
+        for key, shape in self._shapes.items():
+            value = animatable_dict[key]
+            assert isinstance(value, np.ndarray)
+            value = value.reshape(shape)
+            animatable_dict[key] = value
+
+        if hasattr(self, "_transform_import_animatable_dict"):
+            animatable_dict = self._transform_import_animatable_dict(animatable_dict)
+
+        kwargs = {**self._init_kwargs, **animatable_dict}
+        # Need to use cls instead of self.__class__ because otherwise the init kwargs
+        # might be wrong for classes that inherit from auto_animatable classes.
+        # This does mean that Child.copy_with_animatables will return a Parent if not
+        # overriden, but that's true throughout iceberg anyway.
+        return cls(**kwargs)
+
+    cls.copy_with_animatables = copy_with_animatables
+
+    return type(cls.__name__, (cls, Animatable), {})

--- a/iceberg/core/properties.py
+++ b/iceberg/core/properties.py
@@ -7,7 +7,7 @@ import skia
 import numpy as np
 
 from iceberg.geometry import apply_transform
-from iceberg.animation.animatable import Animatable
+from iceberg.animation import Animatable, auto_animatable
 
 
 class Corner(object):
@@ -24,7 +24,8 @@ class Corner(object):
     CENTER = 8
 
 
-class Bounds(Animatable):
+@auto_animatable
+class Bounds:
     """Represents a bounding box."""
 
     def __init__(
@@ -77,14 +78,6 @@ class Bounds(Animatable):
         self._bottom = bottom
 
         self._compute_corners()
-
-    @property
-    def animatables(self):
-        return [np.array([self.left, self.top, self.right, self.bottom])]
-
-    def copy_with_animatables(self, animatables):
-        scalars = animatables[0]
-        return Bounds(*scalars)
 
     def transform(self, transform: np.ndarray):
         """Transform the bounds by the specified transform matrix.
@@ -246,6 +239,8 @@ class Bounds(Animatable):
 
 
 class Color(Animatable):
+    # Can't use auto_animatable here because that won't work for the @classmethods.
+    # TODO(ejnnr): could add another decorator specifically for the classmethods.
     def __init__(self, r: float, g: float, b: float, a: float = 1.0) -> None:
         """Create a color object.
 
@@ -418,7 +413,8 @@ class StrokeCap(Enum):
     SQUARE = skia.Paint.kSquare_Cap
 
 
-class PathStyle(Animatable):
+@auto_animatable
+class PathStyle:
     """A style for drawing paths."""
 
     def __init__(
@@ -462,17 +458,6 @@ class PathStyle(Animatable):
             )
             if dashed
             else None,
-        )
-
-    @property
-    def animatables(self):
-        return [self.color, self.thickness]
-
-    def copy_with_animatables(self, animatables):
-        color, thickness = animatables
-
-        return PathStyle(
-            color, thickness, self._anti_alias, self._stroke, self._stroke_cap
         )
 
     @property

--- a/iceberg/primitives/shapes.py
+++ b/iceberg/primitives/shapes.py
@@ -149,6 +149,7 @@ class PartialPath(Drawable):
     class Interpolation(Enum):
         LINEAR = 0
         CUBIC = 1
+
     def __init__(
         self,
         child_path: Path,
@@ -249,9 +250,6 @@ class PartialPath(Drawable):
     @property
     def bounds(self) -> Bounds:
         return self._child_path.bounds
-
-    @property
-
 
 
 @auto_animatable


### PR DESCRIPTION
(This is super hacky and I'll understand if you don't want it to be part of core iceberg xD)

Problem: while many iceberg Drawables are Animatable via inheritance from Compose, this inheritance often doesn't do what you'd want, mainly because tweening them returns instances of Compose, which may be missing some methods of the original class. (There are also cases where the inheritance doesn't help at all, namely if the children are not Animatable.)

That can lead to boilerplate code that essentially just
* stores the arguments to `__init__`,
* defines `animatables()` by returning some subset of those arguments,
* sometimes dynamically figures out whether a child Drawable is animatable,
* defines `copy_with_animatables()` by using the captured `__init__` arguments and the animatables.

To avoid this boilerplate code, this PR introduces a class decorator, `auto_animatable`, that decorates a `Drawable` and does its best to make it `Animatable` by doing these steps automatically.

This decorator works for most of the current Animatable classes in iceberg, and the new ones in the curved arrow branch (but there are definitely cases where it wouldn't work and you'd have to implement things manually).

Usage:
```
@auto_animatable
class MyClass(Drawable):
    def __init__(
        self,
        a: float,
        b: list[tuple[float, float]],
        c: np.ndarray,
        d: Drawable,
        e: str,
    ):
        ...
```
If `my_obj` is an instance of `MyClass`, then
* `isinstance(my_obj, Animatable)` is true
* `my_obj.animatables` will give `a` to `c`, and `d` if the argument was `Animatable`, but not `e`. (This is assuming the arguments to `__init__` had the types indicated by the annotations above---`auto_animatable` uses the actual values to infer types, not type annotations.)
* `my_obj.copy_with_animatable` will work as expected

Note that `MyClass` mustn't explicitly inherit from `Animatable`---this would lead to errors as `MyClass` wouldn't have the necessary abstract methods defined. Instead, the decorator will add `Animatable` as a parent class. (Technically, it returns a new class that inherits from `MyClass` and `Animatable`)

You can modify the animatables by defining `_transform_export_animatable_dict` and/or `_transform_import_animatable_dict` methods on the class. Both take a dict where keys are names of animatable `__init__` kwargs, and values are the `__init__` arguments. The methods can then return a modified dict. For example, `Rectangle` uses this to transform `padding` into a 4-tuple, so that tweening between a Rectangle where padding was a float and a more general Rectangle works.

Main issues I see:
* The decorator creating a new class that subclasses the original one and Animatable is really hacky and might lead to issues with linters, autocompletion, etc. Would be nice to find another solution for this.
* Because it magically works for most cases, people who don't know the library very well might use it in cases where it doesn't work and then get confusing error messages (in particular given that they don't even need to understand how `Animatables` work anymore to implement them).
* All the tests pass and it works in a few examples I tried, but I totally might have broken something given that animation isn't covered by tests. I can try to add some more tests before merging.