### PR TITLE
Relax skia-python version requirements to >=87.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 absl-py>=1.0.0
 glfw==2.5.1
 numpy>=1.21.0
-skia-python==87.5
+skia-python>=87.5
 tqdm>=4.62.3
 av>=11.0.0
 Pillow>=10.1.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "absl-py>=1.0.0",
         "glfw==2.5.1",
         "numpy>=1.21.0",
-        "skia-python==87.5",
+        "skia-python>=87.5",
         "tqdm>=4.62.3",
         "av>=11.0.0",
         "Pillow>=10.1.0",


### PR DESCRIPTION
When installing with python 3.12.2, I got the following error:

```
ERROR: Ignored the following versions that require a different python version: 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11
ERROR: Could not find a version that satisfies the requirement skia-python==87.5 (from iceberg-dsl) (from versions: 87.6, 119.0b4, 120.0b5, 121.0b6, 124.0b7, 126.0b8)
ERROR: No matching distribution found for skia-python==87.5
```

Relaxing the skia-python version to >=87.5 fixed the issue.