### PR TITLE
Fix GridOverlay and expose in top-level namespace

### DIFF
--- a/iceberg/__init__.py
+++ b/iceberg/__init__.py
@@ -50,6 +50,7 @@ from iceberg.primitives import (
     SmoothPath,
     Point,
     CubicBezier,
+    GridOverlay,
 )
 
 
@@ -131,6 +132,7 @@ __all__ = [
     "CubicBezier",
     "SVGPath",
     "Brace",
+    "GridOverlay",
 ]
 
 # Expose commonly used classes and enums directly in the iceberg namespace.

--- a/iceberg/primitives/shapes.py
+++ b/iceberg/primitives/shapes.py
@@ -460,8 +460,8 @@ class GridOverlay(DrawableWithChild):
             if i % self.label_every == x_offset_index:
                 labels.append(
                     SimpleText(
-                        str(round(x)),
-                        font_style,
+                        text=str(round(x)),
+                        font_style=font_style,
                     ).move(x, y_lower - 5, corner=Corner.BOTTOM_MIDDLE)
                 )
 
@@ -469,8 +469,8 @@ class GridOverlay(DrawableWithChild):
             if i % self.label_every == y_offset_index:
                 labels.append(
                     SimpleText(
-                        str(round(y)),
-                        font_style,
+                        text=str(round(y)),
+                        font_style=font_style,
                     ).move(x_lower - 5, y, corner=Corner.MIDDLE_RIGHT)
                 )
 


### PR DESCRIPTION
Looks like GridOverlay wasn't updated when we switched to the new dataclass-style Drawables